### PR TITLE
Fix case-sensitive file reference in Popup.html

### DIFF
--- a/Popup.html
+++ b/Popup.html
@@ -107,6 +107,6 @@
     Text-Zusammenfasser Pro v1.1
   </div>
   
-  <script src="popup.js"></script>
+  <script src="Popup.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Updated script reference from 'popup.js' to 'Popup.js' to match actual filename.
This prevents loading issues on case-sensitive file systems (Linux, macOS).